### PR TITLE
Use ResolvedSchema instead of deprecated TableSchema

### DIFF
--- a/src/main/java/org/apache/flink/connector/clickhouse/ClickHouseDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/connector/clickhouse/ClickHouseDynamicTableFactory.java
@@ -46,7 +46,10 @@ public class ClickHouseDynamicTableFactory implements DynamicTableSinkFactory {
         ReadableConfig config = helper.getOptions();
         helper.validate();
         this.validateConfigOptions(config);
-        return new ClickHouseDynamicTableSink(getOptions(config), context.getCatalogTable());
+        return new ClickHouseDynamicTableSink(
+                getOptions(config),
+                context.getCatalogTable(),
+                context.getCatalogTable().getResolvedSchema());
     }
 
     @Override

--- a/src/main/java/org/apache/flink/connector/clickhouse/internal/AbstractClickHouseOutputFormat.java
+++ b/src/main/java/org/apache/flink/connector/clickhouse/internal/AbstractClickHouseOutputFormat.java
@@ -12,7 +12,7 @@ import org.apache.flink.connector.clickhouse.internal.executor.ClickHouseExecuto
 import org.apache.flink.connector.clickhouse.internal.options.ClickHouseOptions;
 import org.apache.flink.connector.clickhouse.internal.partitioner.ClickHousePartitioner;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
-import org.apache.flink.table.api.constraints.UniqueConstraint;
+import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.RowData.FieldGetter;
 import org.apache.flink.table.types.DataType;


### PR DESCRIPTION
`ResolvedSchema`, `org.apache.flink.table.api.constraints.UniqueConstraint` are  deprecdated
the PR suggests usage of `ResolvedSchema` and  `org.apache.flink.table.api.constraints.UniqueConstraint`