### PR TITLE
Replace deprecated TableSchema with ResolvedSchema

### DIFF
--- a/src/main/java/org/apache/flink/connector/clickhouse/ClickHouseDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/connector/clickhouse/ClickHouseDynamicTableFactory.java
@@ -4,14 +4,13 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.clickhouse.internal.options.ClickHouseDmlOptions;
 import org.apache.flink.connector.clickhouse.internal.options.ClickHouseReadOptions;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.factories.FactoryUtil.TableFactoryHelper;
-import org.apache.flink.table.utils.TableSchemaUtils;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -70,8 +69,7 @@ public class ClickHouseDynamicTableFactory
 
         Properties clickHouseProperties =
                 getClickHouseProperties(context.getCatalogTable().getOptions());
-        TableSchema physicalSchema =
-                TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
+        ResolvedSchema physicalSchema = context.getCatalogTable().getResolvedSchema();
         return new ClickHouseDynamicTableSource(
                 getReadOptions(config),
                 clickHouseProperties,


### PR DESCRIPTION
The PR replaces deprecated `TableSchema` with `ResolvedSchema`

Also it removes usage of `TableSchemaUtils#projectSchema` since this method is already removed in later Flink versions