### PR TITLE
upsert  by updating row if it exists   and inserting otherwise

### DIFF
--- a/src/main/java/org/apache/flink/connector/clickhouse/internal/ClickHouseStatementFactory.java
+++ b/src/main/java/org/apache/flink/connector/clickhouse/internal/ClickHouseStatementFactory.java
@@ -94,6 +94,18 @@ public class ClickHouseStatementFactory {
                 conditionClause);
     }
 
+    public static String getExistStatement(
+            String tableName, String databaseName, String[] conditionFields) {
+        String conditionClause =
+                Arrays.stream(conditionFields)
+                        .map((f) -> quoteIdentifier(f) + "=?")
+                        .collect(joining(" AND "));
+        return "SELECT 1 FROM "
+                + fromTableClause(tableName, databaseName)
+                + " WHERE "
+                + conditionClause;
+    }
+
     private static String fromTableClause(String tableName, String databaseName) {
         if (databaseName == null) {
             return quoteIdentifier(tableName);

--- a/src/main/java/org/apache/flink/connector/clickhouse/internal/executor/ClickHouseExecutor.java
+++ b/src/main/java/org/apache/flink/connector/clickhouse/internal/executor/ClickHouseExecutor.java
@@ -145,7 +145,6 @@ public interface ClickHouseExecutor extends Serializable {
                 Arrays.stream(updFields).mapToObj(f -> fieldTypes[f]).toArray(LogicalType[]::new);
 
         return new ClickHouseUpsertExecutor(
-                keyFields,
                 insertSql,
                 updateSql,
                 deleteSql,

--- a/src/main/java/org/apache/flink/connector/clickhouse/internal/executor/ClickHouseUpsertExecutor.java
+++ b/src/main/java/org/apache/flink/connector/clickhouse/internal/executor/ClickHouseUpsertExecutor.java
@@ -29,8 +29,6 @@ public class ClickHouseUpsertExecutor implements ClickHouseExecutor {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseShardOutputFormat.class);
 
-    private final String[] keyFields;
-
     private final String insertSql;
 
     private final String updateSql;
@@ -66,7 +64,6 @@ public class ClickHouseUpsertExecutor implements ClickHouseExecutor {
     private transient ClickHouseConnectionProvider connectionProvider;
 
     public ClickHouseUpsertExecutor(
-            String[] keyFields,
             String insertSql,
             String updateSql,
             String deleteSql,
@@ -79,7 +76,6 @@ public class ClickHouseUpsertExecutor implements ClickHouseExecutor {
             Function<RowData, RowData> deleteExtractor,
             Function<RowData, RowData> existExtractor,
             ClickHouseDmlOptions options) {
-        this.keyFields = keyFields;
         this.insertSql = insertSql;
         this.updateSql = updateSql;
         this.deleteSql = deleteSql;


### PR DESCRIPTION
When execute multiple same insert statements in upsert mode, flink-connector-clickhouse did not update these document, it appended these document to Clickhouse instead. 