### PR TITLE
[bug fix] fix build sql error in ClickHouseDynamicTableSource

### DIFF
--- a/src/main/java/org/apache/flink/connector/clickhouse/internal/ClickHouseStatementFactory.java
+++ b/src/main/java/org/apache/flink/connector/clickhouse/internal/ClickHouseStatementFactory.java
@@ -19,8 +19,8 @@ public class ClickHouseStatementFactory {
         String columns =
                 fieldNames.length != 0
                         ? Arrays.stream(fieldNames)
-                        .map(ClickHouseStatementFactory::quoteIdentifier)
-                        .collect(joining(", "))
+                                .map(ClickHouseStatementFactory::quoteIdentifier)
+                                .collect(joining(", "))
                         : "''";
         return String.join(
                 EMPTY, "SELECT ", columns, " FROM ", fromTableClause(tableName, databaseName));

--- a/src/main/java/org/apache/flink/connector/clickhouse/internal/ClickHouseStatementFactory.java
+++ b/src/main/java/org/apache/flink/connector/clickhouse/internal/ClickHouseStatementFactory.java
@@ -17,9 +17,11 @@ public class ClickHouseStatementFactory {
     public static String getSelectStatement(
             String tableName, String databaseName, String[] fieldNames) {
         String columns =
-                Arrays.stream(fieldNames)
+                fieldNames.length != 0
+                        ? Arrays.stream(fieldNames)
                         .map(ClickHouseStatementFactory::quoteIdentifier)
-                        .collect(joining(", "));
+                        .collect(joining(", "))
+                        : "''";
         return String.join(
                 EMPTY, "SELECT ", columns, " FROM ", fromTableClause(tableName, databaseName));
     }


### PR DESCRIPTION
simlar to [FLINK-27268](https://issues.apache.org/jira/browse/FLINK-27268), when projection not match any column, it will return 'ROW<> NOT NULL'.